### PR TITLE
Fix small typo in milestone 3

### DIFF
--- a/content/docs/milestone_3/introduction.md
+++ b/content/docs/milestone_3/introduction.md
@@ -15,7 +15,7 @@ weight: 1
 
 # Cross-tick Swaps
 
-We have made a great progress so far and our Uniswap V3 implementation is quote close to the original one! However, our
+We have made a great progress so far and our Uniswap V3 implementation is quite close to the original one! However, our
 implementation only supports swaps within a price range–and this is what we're going to improve in this milestone.
 
 In this milestone, we'll:


### PR DESCRIPTION
Thanks for the great resource! 

This PR fixes a small typo on Cross-tick swaps intro.