### PR TITLE
Add internal functions to example code under providing liquidity.

### DIFF
--- a/content/docs/milestone_1/providing-liquidity.md
+++ b/content/docs/milestone_1/providing-liquidity.md
@@ -284,6 +284,15 @@ if (amount0 > 0 && balance0Before + amount0 > balance0())
     revert InsufficientInputAmount();
 if (amount1 > 0 && balance1Before + amount1 > balance1())
     revert InsufficientInputAmount();
+
+
+function balance0() internal returns (uint256 balance) {
+        balance = IERC20(token0).balanceOf(address(this));
+}
+
+function balance1() internal returns (uint256 balance) {
+        balance = IERC20(token0).balanceOf(address(this));
+}
 ```
 
 First, we record current token balances. Then we call `uniswapV3MintCallback` method on the caller–this is the callback.


### PR DESCRIPTION
I had a problem identifying where the `balance0()` and `balance1()` functions were, till I found them at the bottom of the source code. I believe it will be more convenient to show it in the example code to make it suitable for readers.