### PR TITLE
Fix shouldTransferInCallback to be set before mint

### DIFF
--- a/src/milestone_1/providing-liquidity.md
+++ b/src/milestone_1/providing-liquidity.md
@@ -416,6 +416,8 @@ function setupTestCase(TestCaseParams memory params)
         params.currentTick
     );
 
+    shouldTransferInCallback = params.shouldTransferInCallback;
+
     if (params.mintLiqudity) {
         (poolBalance0, poolBalance1) = pool.mint(
             address(this),
@@ -425,7 +427,6 @@ function setupTestCase(TestCaseParams memory params)
         );
     }
 
-    shouldTransferInCallback = params.shouldTransferInCallback;
 }
 ```
 In this function, we're minting tokens and deploying a pool. Also, when the `mintLiquidity` flag is set, we mint liquidity in the pool. In the end, we're setting the `shouldTransferInCallback` flag for it to be read in the mint callback:


### PR DESCRIPTION
`shouldTransferInCallback` is set before minting so the test can function correctly