### PR TITLE
Fix shouldTransferInCallback to be set before mint & small typo

### DIFF
--- a/src/milestone_1/first-swap.md
+++ b/src/milestone_1/first-swap.md
@@ -153,7 +153,7 @@ function testSwapBuyEth() public {
         liquidity: 1517882343751509868544,
         currentSqrtP: 5602277097478614198912276234240,
         shouldTransferInCallback: true,
-        mintLiqudity: true
+        mintLiquidity: true
     });
     (uint256 poolBalance0, uint256 poolBalance1) = setupTestCase(params);
 

--- a/src/milestone_1/providing-liquidity.md
+++ b/src/milestone_1/providing-liquidity.md
@@ -391,7 +391,7 @@ function testMintSuccess() public {
         liquidity: 1517882343751509868544,
         currentSqrtP: 5602277097478614198912276234240,
         shouldTransferInCallback: true,
-        mintLiqudity: true
+        mintLiquidity: true
     });
 ```
 1. We're planning to deposit 1 ETH and 5000 USDC into the pool.
@@ -418,7 +418,7 @@ function setupTestCase(TestCaseParams memory params)
 
     shouldTransferInCallback = params.shouldTransferInCallback;
 
-    if (params.mintLiqudity) {
+    if (params.mintLiquidity) {
         (poolBalance0, poolBalance1) = pool.mint(
             address(this),
             params.lowerTick,

--- a/src/milestone_1/providing-liquidity.md
+++ b/src/milestone_1/providing-liquidity.md
@@ -416,6 +416,8 @@ function setupTestCase(TestCaseParams memory params)
         params.currentTick
     );
 
+    shouldTransferInCallback = params.shouldTransferInCallback;
+
     if (params.mintLiqudity) {
         (poolBalance0, poolBalance1) = pool.mint(
             address(this),
@@ -425,7 +427,6 @@ function setupTestCase(TestCaseParams memory params)
         );
     }
 
-    shouldTransferInCallback = params.shouldTransferInCallback;
 }
 ```
 In this function, we're minting tokens and deploying a pool. Also, when the `mintLiquidity` flag is set, we mint liquidity in the pool. In the end, we're setting the `shouldTransferInCallback` flag for it to be read in the mint callback:


### PR DESCRIPTION
providing-liquidity.md = shouldTransferInCallback moved so the test function should work correctly

providing-liquidity.md, first-swap.md = fix typo `mintLiqudity` to `mintLiquidity`
