### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Jeiwan"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Uniswap V3 Development Book"
 description = "A book that teaches how to build a clone of Uniswap V3 in Solidity from scratch."


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10